### PR TITLE
Add field existence check for metadata to prevent null-error

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,6 +26,7 @@ export const propertyMap = ({ props }: { props?: string }) => {
 
 /** Sort descending by updated date (when updated is not available, use created date) */
 export const sortByDateDesc = (obj1: LokiObj, obj2: LokiObj) => {
+  if (!obj1.meta || !obj2.meta) return 0;
   const time1 = obj1.meta.updated || obj1.meta.created;
   const time2 = obj2.meta.updated || obj2.meta.created;
   return time1 === time2 ? 0 : time1 > time2 ? -1 : 1;


### PR DESCRIPTION
The sort function did not check for the meta-field's existence. This would lead to errors when trying to sort objects without metadata.